### PR TITLE
fixed visible off error with octave 6.1.1

### DIFF
--- a/fade.d/corpus-speech.d/matlab/figures/figures.m
+++ b/fade.d/corpus-speech.d/matlab/figures/figures.m
@@ -131,7 +131,8 @@ for iex=1:length(exptypes)
   end
 
   %% Visualize data
-  figure('Position',[0 0 600 600],'Visible','on');
+  if is_octave(); figure('Visible','off'); close; graphics_toolkit('gnuplot'); end % fix for octave 6.1.1
+  figure('Position',[0 0 600 600],'Visible','off');
   subplot = @(m,n,p) axes('Position',subposition(m,n,p,[0.125 0.125],[0.035 0.05],[1 1]));
 
   subplot(2,2,1);

--- a/fade.d/corpus-stimulus.d/matlab/figures/evaluate_data.m
+++ b/fade.d/corpus-stimulus.d/matlab/figures/evaluate_data.m
@@ -178,7 +178,8 @@ for ico=1:num_combinations
   x_range = setrange([x_emp(:); x_mod(:)],0.1);
   y_range = setrange([y_emp(:); test_levels(:)],0.1);
 
-  figure('Position',[0 0 400 400],'Visible','on');
+  if is_octave(); figure('Visible','off'); close; graphics_toolkit('gnuplot'); end % fix for octave 6.1.1
+  figure('Position',[0 0 600 600],'Visible','off');
   h2 = plotdev(x_emp,y_emp,e_emp);
   hold on;
   h1 = plot(x_emp,y_emp,'-or');

--- a/fade.d/figures
+++ b/fade.d/figures
@@ -68,7 +68,7 @@ $CONFIG && exit 0
 mkdir -p "${FID}" || exit 1
 
 # Evaluate all conditions
-echo "figures('${EVD}/summary','${FID}','${GITVERSION}' ${FIGARGS})" | run-matlab 'ascii-tools' "${FCD}/matlab"
+echo "figures('${EVD}/summary','${FID}','${GITVERSION}' ${FIGARGS})" | run-matlab 'ascii-tools' 'helper' "${FCD}/matlab"
 
 # Pretty print table if it exists
 if [ -f "${FID}/table.txt" ]; then


### PR DESCRIPTION
Fixed visible off error with octave 6.1.1.
Apparently, octave 6.1.1. sets the graphics_toolkit to fltk after a figure is created:
``` 
% run in terminal with octave-cli
graphics_toolkit('gnuplot');
figure(1,'visible','off');
disp(graphics_toolkit) % --> fltk
```
To set it to gnuplot (which can render graphics without displaying them), close the figure and reset the graphics_toolkit to gnuplot.

Another "fix" is to use `octave` instead of `octave-cli` to start octave (this is defined in `scripts/run-matlab`), but this requires to set gnuplot to the default graphics toolkit (add `graphics_toolkit('gnuplot');` to your `~/.octaverc`)

